### PR TITLE
fix: prevent racing of requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # pull-request-management
 
-TEst
+Test


### PR DESCRIPTION
Introduce a request id and a reference to latest request. Dismiss incoming responses other than from latest request.

Remove timeouts which were used to mitigate the racing issue but are obsolete now.

Adding some more stuff here to see how the linter takes it.  Should be fine.

Reviewed-by: Z
Refs: #123